### PR TITLE
Allow specifying path to UserConfig.txt

### DIFF
--- a/osdk-wrapper/inc/LinuxSetup.h
+++ b/osdk-wrapper/inc/LinuxSetup.h
@@ -31,15 +31,16 @@ typedef struct ackReturnToMobile{
   uint16_t ack;
 } ackReturnToMobile;
 
-int setup(LinuxSerialDevice* serialDevice, CoreAPI* api, LinuxThread* read);
+int setup(LinuxSerialDevice* serialDevice, CoreAPI* api, LinuxThread* read, std::string userConfigPath = UserConfig::defaultUserConfigPath);
 bool validateSerialDevice(LinuxSerialDevice* serialDevice, CoreAPI* api);
-int parseUserConfig();
+int parseUserConfig(std::string userConfigPath = UserConfig::defaultUserConfigPath);
 ackReturnData activate(CoreAPI* api);
 ackReturnData takeControl(CoreAPI* api);
 
 
 //! Non-Blocking calls
-int setupNonBlocking(LinuxSerialDevice* serialDevice, CoreAPI* api, LinuxThread* read, LinuxThread* callback);
+int setupNonBlocking(LinuxSerialDevice* serialDevice, CoreAPI* api, LinuxThread* read, LinuxThread* callback,
+		std::string userConfigPath = UserConfig::defaultUserConfigPath);
 void activateNonBlocking(CoreAPI* api);
 void activateCallback(CoreAPI* api, Header *protHeader, DJI::UserData data);
 void takeControlNonBlocking(CoreAPI* api);

--- a/osdk-wrapper/inc/ReadUserConfig.h
+++ b/osdk-wrapper/inc/ReadUserConfig.h
@@ -32,7 +32,9 @@ using namespace DJI::onboardSDK;
 
 namespace UserConfig
 {
-  //! If using Manifold, the UART2 port shows up as /dev/ttyTHS1. 
+  const std::string defaultUserConfigPath = "UserConfig.txt";
+
+  //! If using Manifold, the UART2 port shows up as /dev/ttyTHS1.
   //! The Expansion I/O port shows up as /dev/ttyTHS0. 
   //! If using a USB-Serial adapter, use /dev/ttyUSB0 
   //! (may differ if you have other USB-Serial devices plugged in)
@@ -48,7 +50,6 @@ namespace UserConfig
   extern Version targetVersion; 
 }
 
-void readUserConfig();
-
+void readUserConfig(std::string UserConfigPath = UserConfig::defaultUserConfigPath);
 
 #endif //USER_CONFIG_H

--- a/osdk-wrapper/src/LinuxSetup.cpp
+++ b/osdk-wrapper/src/LinuxSetup.cpp
@@ -25,10 +25,10 @@ boost::thread workerThread1;
 boost::thread workerThread2;
 #endif
 
-int setup(LinuxSerialDevice* serialDevice, CoreAPI* api, LinuxThread* read)
+int setup(LinuxSerialDevice* serialDevice, CoreAPI* api, LinuxThread* read, std::string userConfigPath)
 {
   //! Configuration parsing
-  int configStatus = parseUserConfig(); 
+  int configStatus = parseUserConfig(userConfigPath);
 
   if (configStatus == -1)
   {
@@ -139,9 +139,9 @@ bool validateSerialDevice(LinuxSerialDevice* serialDevice, CoreAPI* api)
 }
 
 
-int parseUserConfig()
+int parseUserConfig(string userConfigPath)
 {
-  readUserConfig();
+  readUserConfig(userConfigPath);
 
   std::string droneVerStr, SdkVerStr; 
   switch (UserConfig::targetVersion){
@@ -303,10 +303,11 @@ ackReturnData takeControl(CoreAPI* api)
 
 //! Non-Blocking
 
-int setupNonBlocking(LinuxSerialDevice* serialDevice, CoreAPI* api, LinuxThread* read, LinuxThread* callback)
+int setupNonBlocking(LinuxSerialDevice* serialDevice, CoreAPI* api, LinuxThread* read, LinuxThread* callback,
+		std::string userConfigPath)
 {
   //! Configuration parsing
-  int configStatus = parseUserConfig();
+  int configStatus = parseUserConfig(userConfigPath);
 
   if (configStatus == -1)
   {

--- a/osdk-wrapper/src/ReadUserConfig.cpp
+++ b/osdk-wrapper/src/ReadUserConfig.cpp
@@ -36,7 +36,7 @@ namespace UserConfig{
   DJI::onboardSDK::Version targetVersion; 
 }
 
-void readUserConfig()
+void readUserConfig(string UserConfigPath)
 {
   char line[1024];
 
@@ -48,7 +48,7 @@ void readUserConfig()
 
   bool set_ID, set_KEY, set_Baud, set_Serial_Device, set_Drone_Version;
 
-  ifstream read("UserConfig.txt");
+  ifstream read(UserConfigPath);
 
   if (read.is_open())
   {
@@ -100,3 +100,4 @@ void readUserConfig()
          << "and have sufficient permissions." << endl;
   read.close();
 }
+


### PR DESCRIPTION
osdk-wrapper's ReadUserConfig.cpp hard codes user configuration file name as "UserConfig.txt" and hardcodes the file's path to current directory. It would be useful for application developers who leverage osdk-wrapper library to be able to specify path of the user configuration file.