### PR TITLE
Update Receive.cpp

### DIFF
--- a/sample/STM32/OnBoardSDK_STM32/User/Receive.cpp
+++ b/sample/STM32/OnBoardSDK_STM32/User/Receive.cpp
@@ -188,7 +188,7 @@ void USART2_IRQHandler(void)
         myTerminal.rxLength = myTerminal.rxIndex + 1;
         myTerminal.rxIndex = 0;
         myTerminal.cmdReadyFlag = 1;
-        TIM_Cmd(TIM2, ENABLE);
+       
       }
       else
       {

--- a/sample/STM32/OnBoardSDK_STM32/User/Receive.cpp
+++ b/sample/STM32/OnBoardSDK_STM32/User/Receive.cpp
@@ -173,6 +173,7 @@ void USART2_IRQHandler(void)
     {
       if (oneByte == 0xFA)
       {
+        TIM_Cmd(TIM2, DISABLE);
         myTerminal.cmdIn[myTerminal.rxIndex] = oneByte;
         myTerminal.rxIndex = 1;
       }
@@ -187,6 +188,7 @@ void USART2_IRQHandler(void)
         myTerminal.rxLength = myTerminal.rxIndex + 1;
         myTerminal.rxIndex = 0;
         myTerminal.cmdReadyFlag = 1;
+        TIM_Cmd(TIM2, ENABLE);
       }
       else
       {


### PR DESCRIPTION
Disable Timer2 when USARET2 is receiving commands begining with 0xFA in case of the  interfere of Timer2(Timer2 interrupt is prior to USART2 interrupt).