### PR TITLE
Fix compilation bug on Arch (ARM) Linux

### DIFF
--- a/contrib/DJIConfig.cmake
+++ b/contrib/DJIConfig.cmake
@@ -9,7 +9,7 @@ endif()
 
 #Detect platform - from https://gist.github.com/CoolerVoid/1781717
 EXECUTE_PROCESS(
-  COMMAND cat /etc/lsb-release
+  COMMAND `cat /etc/*-release`
   COMMAND grep DISTRIB_RELEASE
   COMMAND awk -F= "{ print $2 }"
   COMMAND tr "\n" " "
@@ -17,11 +17,11 @@ EXECUTE_PROCESS(
   OUTPUT_VARIABLE LSB_VER
   )
 
-if( ${LSB_VER} STREQUAL "16.04")
+if( ${LSB_VER} MATCHES "16.04")
   set(DISTRO_VERSION 1604)
-elseif(${LSB_VER} STREQUAL "14.04")
+elseif(${LSB_VER} MATCHES "14.04")
   set(DISTRO_VERSION 1404)
-elseif(${LSB_VER} STREQUAL "18")
+elseif(${LSB_VER} MATCHES "18")
   set(DISTRO_VERSION 1604)
 else()
   set(DISTRO_VERSION UNKNOWN)

--- a/osdk-wrapper/src/LinuxCamera.cpp
+++ b/osdk-wrapper/src/LinuxCamera.cpp
@@ -9,6 +9,7 @@
  * */
 
 #include <LinuxCamera.h>
+#include <cmath>
 
 void gimbalAngleControlSample(Camera *camera, int timeout) {
 
@@ -170,9 +171,9 @@ void waitForGimbal(Camera *camera) {
       rAngle.yaw = camera->getGimbal().yaw;
       sleep(1);
   }
-  while(fabs(camera->getGimbal().roll - rAngle.roll) >= 0.099 ||
-      fabs(camera->getGimbal().pitch - rAngle.pitch) >= 0.099 ||
-      fabs(camera->getGimbal().yaw - rAngle.yaw) >= 0.099);
+  while(std::fabs(camera->getGimbal().roll - rAngle.roll) >= 0.099 ||
+      std::fabs(camera->getGimbal().pitch - rAngle.pitch) >= 0.099 ||
+      std::fabs(camera->getGimbal().yaw - rAngle.yaw) >= 0.099);
 }
 
 void doSetGimbalAngle(Camera *camera, GimbalContainer *gimbal) {


### PR DESCRIPTION
Cmake was failing in arch arm on Raspberry PI 3. Fixed it using recommended cmake way to compare strings, that is used to find Ubuntu version on compile time
Compilation was failing due to missing header and namespace prefix

Patch has been compiled with success on Arch ARM (RPI 3), and on Ubuntu 16.04