### PR TITLE
Fixes build issue on Ubuntu 17.04

### DIFF
--- a/osdk-wrapper/src/LinuxCamera.cpp
+++ b/osdk-wrapper/src/LinuxCamera.cpp
@@ -9,6 +9,7 @@
  * */
 
 #include <LinuxCamera.h>
+#include <cmath>
 
 void gimbalAngleControlSample(Camera *camera, int timeout) {
 


### PR DESCRIPTION
When building on Ubuntu 17.04/gcc 6.3.0, the build will fail
due to `error: ‘fabs’ was not declared in this scope`. This just
adds cmath to the includes so it will build properly.