### PR TITLE
Fix bug by initializing local bool variables

### DIFF
--- a/sample/linux/common/dji_linux_environment.cpp
+++ b/sample/linux/common/dji_linux_environment.cpp
@@ -83,7 +83,7 @@ DJI_Environment::parse(std::string config_file_path)
   char        devName[20];
   int         id;
 
-  bool setID, setKey, setBaud, setSerialDevice;
+  bool setID = false, setKey = false, setBaud = false, setSerialDevice = false;
   bool result = false;
 
   std::ifstream read(config_file_path);


### PR DESCRIPTION
Since these weren't being initialized, I was seeing unexpected behavior.  Initializing the bool variables fixed the issue.  The reason is that an uninitialized local variable has indeterminate value.