### PR TITLE
Add API for handling flaky serial ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,15 +49,9 @@ build/
 CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake
-<<<<<<< HEAD
-<<<<<<< HEAD
-Makefile
-=======
-Makefile
 
 osdk-core/test
 contrib
->>>>>>> refs/heads/3.3
-=======
-Makefile
->>>>>>> develop
+rpi-build
+*.DS_Store
+cscope.out

--- a/osdk-core/api/inc/dji_vehicle.hpp
+++ b/osdk-core/api/inc/dji_vehicle.hpp
@@ -81,6 +81,8 @@ public:
   Vehicle(bool threadSupport);
   ~Vehicle();
 
+  bool reOpenSerialPort();
+
   Protocol*            protocolLayer;
   DataSubscription*    subscribe;
   DataBroadcast*       broadcast;

--- a/osdk-core/api/src/dji_vehicle.cpp
+++ b/osdk-core/api/src/dji_vehicle.cpp
@@ -61,6 +61,17 @@ Vehicle::Vehicle(bool threadSupport)
   mandatorySetUp();
 }
 
+bool
+Vehicle::reOpenSerialPort()
+{
+  if( protocolLayer )
+  {
+    protocolLayer->getDriver()->init();
+    return protocolLayer->getDriver()->getDeviceStatus();
+  }
+  return false;
+}
+
 void
 Vehicle::mandatorySetUp()
 {
@@ -338,9 +349,15 @@ Vehicle::initPlatformSupport()
     }
   }
 #endif
-  bool readThreadStatus = readThread->createThread();
-  bool cbThreadStatus   = callbackThread->createThread();
-  return (readThreadStatus && cbThreadStatus);
+  if (threadSupported)
+  {
+    bool readThreadStatus = readThread->createThread();
+    bool cbThreadStatus   = callbackThread->createThread();
+    return (readThreadStatus && cbThreadStatus);
+  }
+
+
+  return true;
 }
 
 bool

--- a/osdk-core/platform/linux/src/linux_serial_device.cpp
+++ b/osdk-core/platform/linux/src/linux_serial_device.cpp
@@ -22,6 +22,7 @@ using namespace DJI::OSDK;
 
 LinuxSerialDevice::LinuxSerialDevice(const char* device, uint32_t baudrate)
 {
+  m_serial_fd = -1;
   m_device   = device;
   m_baudrate = baudrate;
 }
@@ -34,6 +35,10 @@ LinuxSerialDevice::~LinuxSerialDevice()
 void
 LinuxSerialDevice::init()
 {
+
+  if( m_serial_fd >= 0 )
+     _serialClose();
+
   DSTATUS("Attempting to open device %s with baudrate %u...\n", m_device,
           m_baudrate);
   if (_serialStart(m_device, m_baudrate) < 0)


### PR DESCRIPTION
- Initialize `LinuxSerialDevice::m_serial_fd=-1`
- Make `LinuxSerialDevice::init()` re-entrant by closing device file if open
- Added helper API to Vehicle to re-init() the protocolLayer's hard driver:
  -    `bool Vehicle::reOpenSerialPort()` calls HardDriver::init() and returns driver status

Bonus: don't crash immediately in `Vehicle::initPlatformSupport()` if started without thread support 