### PR TITLE
Fixes waypointCallback and hotPointCallback never getting called

### DIFF
--- a/osdk-core/api/inc/dji_vehicle.hpp
+++ b/osdk-core/api/inc/dji_vehicle.hpp
@@ -348,12 +348,6 @@ private:
   void ACKHandler(void* eventData);
   void PushDataHandler(void* eventData);
 
-  /*
-   * Used in PushData event handling
-   */
-  bool hotPointData;
-  bool wayPointData;
-
   VehicleCallBackHandler hotPointCallback;
   VehicleCallBackHandler wayPointCallback;
   VehicleCallBackHandler missionCallback;

--- a/osdk-core/api/src/dji_vehicle.cpp
+++ b/osdk-core/api/src/dji_vehicle.cpp
@@ -1362,29 +1362,23 @@ Vehicle::PushDataHandler(void* eventData)
           case MISSION_WAYPOINT:
             if (missionManager->wpMission)
             {
-              if (wayPointData)
-              {
-                if (missionManager->wpMission->wayPointCallback.callback)
-                  missionManager->wpMission->wayPointCallback.callback(
-                    this, *(pushDataEntry),
-                    missionManager->wpMission->wayPointCallback.userData);
-                else
-                  DDEBUG("Mode WayPoint\n");
-              }
+              if (missionManager->wpMission->wayPointCallback.callback)
+                missionManager->wpMission->wayPointCallback.callback(
+                  this, *(pushDataEntry),
+                  missionManager->wpMission->wayPointCallback.userData);
+              else
+                DDEBUG("Mode WayPoint\n");
             }
             break;
           case MISSION_HOTPOINT:
             if (missionManager->hpMission)
             {
-              if (hotPointData)
-              {
-                if (missionManager->hpMission->hotPointCallback.callback)
-                  missionManager->hpMission->hotPointCallback.callback(
-                    this, *(pushDataEntry),
-                    missionManager->hpMission->hotPointCallback.userData);
-                else
-                  DDEBUG("Mode HotPoint\n");
-              }
+              if (missionManager->hpMission->hotPointCallback.callback)
+                missionManager->hpMission->hotPointCallback.callback(
+                  this, *(pushDataEntry),
+                  missionManager->hpMission->hotPointCallback.userData);
+              else
+                DDEBUG("Mode HotPoint\n");
             }
             break;
           case MISSION_IOC:


### PR DESCRIPTION
The variables hotPointData and waypoint data never get set, but
they're guarding these callbacks. Removed these variables and the
checks around the callback calls.