### PR TITLE
Fixes to the Vehicle threadSupport flag

### DIFF
--- a/osdk-core/protocol/inc/dji_open_protocol.hpp
+++ b/osdk-core/protocol/inc/dji_open_protocol.hpp
@@ -270,12 +270,12 @@ private:
     uint8_t encode;
   } SDKFilter;
 
+public:
   //! Lowest-level function interfaces with SerialDevice
   bool readPoll(RecvContainer* allocatedRecvObject);
 
   //! Handle incoming data - byte level
   //! STM32 uses it directly
-public:
   bool byteHandler(const uint8_t in_data, RecvContainer* allocatedRecvObject);
   //! Get the bufReadPos variable that tracks how much of the current serial buffer we have consumed
   int getBufReadPos();


### PR DESCRIPTION
Both Vehicle constructors now do the right thing when the threadSupport flag is set to false. In this case, the client is responsible for calling on Vehicle::functionalSetup(), and then continuously calling on Protocol::receive()+ Vehicle::processReceivedData.

Vehicle::callbackPoll() will currently crash if the threadSupport flag is set, however it's not clear to me that this function should be called when threadSupport is disabled anyway.

This pull request also exposes the Protocol::readAll() method, so that a client thread doesn't need to call on receive() and wait for a whole frame to arrive; it can, for example, be event driven - i.e. use select() on the serial port fd and call in only when there is data there to process, and do other things with the rest of it's time.
