### PR TITLE
Fixed receive thread deadlock.

### DIFF
--- a/osdk-core/platform/linux/src/posix_thread.cpp
+++ b/osdk-core/platform/linux/src/posix_thread.cpp
@@ -121,7 +121,8 @@ PosixThread::read_call(void* param)
   while (!(vehiclePtr->getStopCond()))
   {
     // receive() implemented on the OpenProtocol side
-    recvContainer = vehiclePtr->protocolLayer->receive();
+    auto stop = [vehiclePtr](){ return vehiclePtr->getStopCond(); };
+    recvContainer = vehiclePtr->protocolLayer->receive(stop);
     vehiclePtr->processReceivedData(recvContainer);
     usleep(10); //! @note CPU optimization, reduce the CPU usage a lot
   }

--- a/osdk-core/protocol/inc/dji_open_protocol.hpp
+++ b/osdk-core/protocol/inc/dji_open_protocol.hpp
@@ -38,6 +38,8 @@
 #include <string.h>
 #endif
 
+#include <functional>
+
 namespace DJI
 {
 namespace OSDK
@@ -225,7 +227,7 @@ public:
 
   /************************Receive Management********************************/
 
-  RecvContainer receive();
+  RecvContainer receive(std::function<bool()> stop);
   /************************Getters and setters*******************************/
 
   /**

--- a/osdk-core/protocol/src/dji_open_protocol.cpp
+++ b/osdk-core/protocol/src/dji_open_protocol.cpp
@@ -488,7 +488,7 @@ Protocol::sendPoll()
 
 //! Step 0: Call this in a loop.
 RecvContainer
-Protocol::receive()
+Protocol::receive(std::function<bool()> stop)
 {
   //! Create a local container that will be used for storing data lower down in
   //! the stack
@@ -496,8 +496,11 @@ Protocol::receive()
   receiveFrame.recvInfo.cmd_id = 0xFF;
 
   //! Run the readPoll until you get a true
-  // @todo might need to modify to include thread stopCond
-  while (!readPoll(&receiveFrame));
+  while (!stop()) {
+    if (readPoll(&receiveFrame))
+      break;
+  }
+
   //! When we receive a true, return a copy of container to the caller: this is
   //! the 'receive' interface
 


### PR DESCRIPTION
Receive thread could not terminate until at least one packet was read after the thread's stop flag was set.  This caused the software to hang if a Vehicle object was instantiated, but no autopilot was communicating.  

TL:DR
The comment "@todo might need to modify to include thread stopCond" was correct that the thread needed to check the stop condition.