### PR TITLE
Fix issue #224 (added #include <sys/select.h> for fd_set)

### DIFF
--- a/osdk-core/platform/linux/inc/linux_serial_device.hpp
+++ b/osdk-core/platform/linux/inc/linux_serial_device.hpp
@@ -40,6 +40,7 @@
 #include <fcntl.h>
 #include <termios.h>
 #include <unistd.h>
+#include <sys/select.h>
 
 #include "dji_hard_driver.hpp"
 


### PR DESCRIPTION
Build confirmed to be broken in Ubuntu 18.04 (gcc 7.3.0) prior to applying this fix (missing fd_set). Include file iaw POSIX.1-2001, POSIX.1-2008 according to man select(2).