### PR TITLE
Added missing include and missing return statements

### DIFF
--- a/osdk-core/platform/linux/inc/linux_serial_device.hpp
+++ b/osdk-core/platform/linux/inc/linux_serial_device.hpp
@@ -40,6 +40,7 @@
 #include <fcntl.h>
 #include <termios.h>
 #include <unistd.h>
+#include <sys/select.h>
 
 #include "dji_hard_driver.hpp"
 
@@ -71,7 +72,7 @@ public:
   //! your serial connection
   int checkBaudRate(uint8_t (&buf)[BUFFER_SIZE])
   {
-    _checkBaudRate(buf);
+    return _checkBaudRate(buf);
   }
   int setSerialPureTimedRead();
   int unsetSerialPureTimedRead();

--- a/osdk-core/platform/linux/src/posix_thread.cpp
+++ b/osdk-core/platform/linux/src/posix_thread.cpp
@@ -134,6 +134,7 @@ PosixThread::send_call(void* param)
     vehiclePtr->protocolLayer->sendPoll();
     usleep(10); //! @note CPU optimization, reduce the CPU usage a lot
   }
+  return NULL;
 }
 
 void*
@@ -159,6 +160,7 @@ PosixThread::uart_serial_read_call(void* param)
 
   delete recvContainer_copy;
   DDEBUG("Quit read function\n");
+  return NULL;
 }
 
 void*
@@ -184,6 +186,7 @@ PosixThread::USB_read_call(void* param)
 
   delete recvContainer;
   DDEBUG("Quit USB read function\n");
+  return NULL;
 }
 
 void*
@@ -196,4 +199,5 @@ PosixThread::callback_call(void* param)
     usleep(10); //! @note CPU optimization, reduce the CPU usage a lot
   }
   DDEBUG("Quit callback function\n");
+  return NULL;
 }


### PR DESCRIPTION
In `osdk-core/platform/linux/inc/linux_serial_device.hpp`, line 97 the type `fd_set` is used, but the required include is missing.

According to the man page for `fd_set`, one has to include `<sys/select.h>` according to POSIX.1-2001 and POSIX.1-2008. However, this file was not included.

In addition, some return statements were missing.