### PR TITLE
keeping the namespace on the include directory of the cmake finder

### DIFF
--- a/osdk-core/cmake-modules/DJIOSDKConfig.cmake.in
+++ b/osdk-core/cmake-modules/DJIOSDKConfig.cmake.in
@@ -5,7 +5,7 @@
 
 # Compute paths
 get_filename_component(DJIOSDK_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(DJIOSDK_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+set(DJIOSDK_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@/..")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 include("${DJIOSDK_CMAKE_DIR}/djiosdkTargets.cmake")


### PR DESCRIPTION
Fixing the CMake finder generator to be able to keep the namespace in the include directory as required in some other DJI libraries as https://github.com/dji-sdk/Onboard-SDK-ROS.
The version without the fix is not working when installing the library on a location different than the system location.