### PR TITLE
Update down cast to up cast

### DIFF
--- a/osdk-core/platform/manifold/src/DJIHardDriverManifold.cpp
+++ b/osdk-core/platform/manifold/src/DJIHardDriverManifold.cpp
@@ -90,7 +90,7 @@ HardDriverManifold::setDevice(std::string device)
 DJI::OSDK::time_ms
 HardDriverManifold::getTimeStamp()
 {
-  return (uint32_t)time(NULL);
+  return (uint64_t)time(NULL);
 }
 
 size_t


### PR DESCRIPTION
I found that `DJI::OSDK::time_ms` is declared as `uint64_t`, but `getTimeStamp()`'s return value is casted down to `uint32_t`.
I understand the Year 2038 problem, but since `time_t` is redefined as 64 bit signed integer now, I believe there is no merit of actually down casting the return value of `time()`.
Hence, I made a change of cast value to `uint64_t`.

Thanks in advance for your consideration.