### PR TITLE
add base include directory to DJIOSDFConfig.cmake

### DIFF
--- a/osdk-core/cmake-modules/DJIOSDKConfig.cmake.in
+++ b/osdk-core/cmake-modules/DJIOSDKConfig.cmake.in
@@ -5,7 +5,9 @@
 
 # Compute paths
 get_filename_component(DJIOSDK_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(DJIOSDK_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+set(DJIOSDK_INCLUDE_DIRS
+    "@CONF_INCLUDE_DIRS@"
+    "@CONF_INCLUDE_DIRS@/..")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 include("${DJIOSDK_CMAKE_DIR}/djiosdkTargets.cmake")


### PR DESCRIPTION
Currently the generated `DJIOSDKConfig.cmake` does not add the base include directory to the `DJIOSDK_INCLUDE_DIRS` variable. This causes some programs which depend on the `djiosdk` to fail to compile, such as the [DJI Onboard SDK ROS](https://github.com/dji-sdk/Onboard-SDK-ROSl).

If the base include directory is not added to `DJIOSDK_INCLUDE_DIRS`, one cannot include headers as
```cpp
#include <djiosdk/dji_vehicle.hpp>
```
Include is only possible via
```cpp
#include <dji_vehicle.hpp>
```

In some cases, this bug might go unnoticed if one installs the `djiosdk` in a directory that is usually included by some other dependency, such as `/usr/include`.

I changed the `DJIOSDKConfig.cmake` to allow both include possibilities
```cpp
#include <djiosdk/dji_vehicle.hpp>
#include <dji_vehicle.hpp>
```
to avoid compatibility issues.