### PR TITLE
ENH:remove the internal log of OSDK on STM32 platform

### DIFF
--- a/sample/platform/STM32/OnBoardSDK_STM32/User/dji_stm32_helpers.cpp
+++ b/sample/platform/STM32/OnBoardSDK_STM32/User/dji_stm32_helpers.cpp
@@ -45,7 +45,7 @@ STM32Setup::~STM32Setup()
 }
 
 static E_OsdkStat OsdkUser_Console(const uint8_t *data, uint16_t dataLen) {
-  //printf("%s", data);
+  return OSDK_STAT_OK;
   DJI::OSDK::Log::instance().print("%s", data);
   return OSDK_STAT_OK;
 }


### PR DESCRIPTION
Remove the internal log of OSDK on STM32 platform