### PR TITLE
fix:fix the flight-control sample timeout issues

### DIFF
--- a/sample/core/inc/flight_sample.hpp
+++ b/sample/core/inc/flight_sample.hpp
@@ -123,7 +123,7 @@ class FlightSample {
 
   bool moveByPositionOffset(const Vector3f &offsetDesired,
                             float yawDesiredInDeg,
-                            float posThresholdInM = 0.5,
+                            float posThresholdInM = 0.8,
                             float yawThresholdInDeg = 1.0);
 
  private:

--- a/sample/platform/STM32/OnBoardSDK_STM32/User/main.cpp
+++ b/sample/platform/STM32/OnBoardSDK_STM32/User/main.cpp
@@ -196,9 +196,9 @@ void *mainLoopTask(void *p){
             zPosition = 1.2;
           }
 
-          moveByPositionOffset(0, 6, zPosition, 0);
-          moveByPositionOffset(6, 0, zPosition, 0);
-          moveByPositionOffset(-6, -6, zPosition, 0);
+          moveByPositionOffset(0, 6, zPosition, 0, 0.8, 1);
+          moveByPositionOffset(6, 0, zPosition, 0, 0.8, 1);
+          moveByPositionOffset(-6, -6, zPosition, 0, 0.8, 1);
           // Run monitored landing sample
           monitoredLanding();
           break;

--- a/sample/platform/linux/flight-control/flight_control_sample.hpp
+++ b/sample/platform/linux/flight-control/flight_control_sample.hpp
@@ -69,7 +69,7 @@ bool monitoredTakeoff(DJI::OSDK::Vehicle* vehiclePtr, int timeout = 1);
 !*/
 bool moveByPositionOffset(DJI::OSDK::Vehicle *vehicle, float xOffsetDesired,
                           float yOffsetDesired, float zOffsetDesired,
-                          float yawDesired, float posThresholdInM = 0.5,
+                          float yawDesired, float posThresholdInM = 0.8,
                           float yawThresholdInDeg = 1.0);
 
 /*! Monitored Landing (Blocking API call). Return status as well as ack.

--- a/sample/platform/linux/flight-control/main.cpp
+++ b/sample/platform/linux/flight-control/main.cpp
@@ -79,11 +79,11 @@ int main(int argc, char** argv) {
     case 'b':
       monitoredTakeoff(vehicle);
       DSTATUS("Take off over!\n");
-      moveByPositionOffset(vehicle, 0, 6, 6, 30);
+      moveByPositionOffset(vehicle, 0, 6, 6, 30, 0.8, 1);
       DSTATUS("Step 1 over!\n");
-      moveByPositionOffset(vehicle, 6, 0, -3, -30);
+      moveByPositionOffset(vehicle, 6, 0, -3, -30, 0.8, 1);
       DSTATUS("Step 2 over!\n");
-      moveByPositionOffset(vehicle, -6, -6, 0, 0);
+      moveByPositionOffset(vehicle, -6, -6, 0, 0, 0.8, 1);
       DSTATUS("Step 3 over!\n");
       monitoredLanding(vehicle);
       break;
@@ -97,10 +97,10 @@ int main(int argc, char** argv) {
           FlightController::AvoidEnable::AVOID_ENABLE, 1);
 
       /*! Move to higher altitude */
-      flightSample->moveByPositionOffset((FlightSample::Vector3f){0, 0, 30}, 0);
+      flightSample->moveByPositionOffset((FlightSample::Vector3f){0, 0, 30}, 0, 0.8, 1);
 
       /*! Move a short distance*/
-      flightSample->moveByPositionOffset((FlightSample::Vector3f){10, 0, 0}, 0);
+      flightSample->moveByPositionOffset((FlightSample::Vector3f){10, 0, 0}, 0, 0.8, 1);
 
       /*! Set aircraft current position as new home location */
       flightSample->setNewHomeLocation();
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
       flightSample->setGoHomeAltitude(50);
 
       /*! Move to another position */
-      flightSample->moveByPositionOffset((FlightSample::Vector3f){20, 0, 0}, 0);
+      flightSample->moveByPositionOffset((FlightSample::Vector3f){20, 0, 0}, 0, 0.8, 1);
 
       vehicle->flightController->setCollisionAvoidanceEnabledSync(
         FlightController::AvoidEnable::AVOID_DISABLE, 1);

--- a/sample/platform/linux/mobile/mobile_sample.cpp
+++ b/sample/platform/linux/mobile/mobile_sample.cpp
@@ -363,9 +363,9 @@ runPositionControlSample(Vehicle* vehicle)
 {
   bool positionControlError = false;
   positionControlError      = monitoredTakeoff(vehicle);
-  positionControlError &= moveByPositionOffset(vehicle, 0, 6, 6, 30);
-  positionControlError &= moveByPositionOffset(vehicle, 6, 0, -3, -30);
-  positionControlError &= moveByPositionOffset(vehicle, -6, -6, 0, 0);
+  positionControlError &= moveByPositionOffset(vehicle, 0, 6, 6, 30, 0.8, 1);
+  positionControlError &= moveByPositionOffset(vehicle, 6, 0, -3, -30, 0.8, 1);
+  positionControlError &= moveByPositionOffset(vehicle, -6, -6, 0, 0, 0.8, 1);
   positionControlError &= monitoredLanding(vehicle);
 
   return (!positionControlError); // We want to return success status, not error


### PR DESCRIPTION
Fix the flight-control sample timeout issues by enlarge the target area.
By the way, we also show how to adjust the target accuracy.