### PR TITLE
fix:fix running crush issue when get camera stream on M300

### DIFF
--- a/osdk-core/advanced-sensing/api/src/dji_advanced_sensing.cpp
+++ b/osdk-core/advanced-sensing/api/src/dji_advanced_sensing.cpp
@@ -513,11 +513,11 @@ bool AdvancedSensing::startMainCameraStream(CameraImageCallback cb, void * cbPar
 void AdvancedSensing::stopFPVCameraStream()
 {
   if (vehicle_ptr->isM300()) {
+    stopH264Stream(LiveView::OSDK_CAMERA_POSITION_FPV);
     auto deocderPair = streamDecoder.find(LiveView::OSDK_CAMERA_POSITION_FPV);
     if ((deocderPair != streamDecoder.end()) && deocderPair->second) {
       deocderPair->second->cleanup();
     }
-    stopH264Stream(LiveView::OSDK_CAMERA_POSITION_FPV);
   } else {
     fpvCam_ptr->stopCameraStream();
   }
@@ -526,11 +526,11 @@ void AdvancedSensing::stopFPVCameraStream()
 void AdvancedSensing::stopMainCameraStream()
 {
   if (vehicle_ptr->isM300()) {
+    stopH264Stream(LiveView::OSDK_CAMERA_POSITION_NO_1);
     auto deocderPair = streamDecoder.find(LiveView::OSDK_CAMERA_POSITION_NO_1);
     if ((deocderPair != streamDecoder.end()) && deocderPair->second) {
       deocderPair->second->cleanup();
     }
-    stopH264Stream(LiveView::OSDK_CAMERA_POSITION_NO_1);
   } else {
     mainCam_ptr->stopCameraStream();
   }


### PR DESCRIPTION
When getting camera stream on M300, the deinit process before the
unsucription will cause the NULL pointer access issue. Now fix it.