### PR TITLE
Include <string> mmap_file_buffer.hpp

### DIFF
--- a/osdk-core/modules/inc/filemgr/impl/mmap_file_buffer.hpp
+++ b/osdk-core/modules/inc/filemgr/impl/mmap_file_buffer.hpp
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <memory>
 #include <atomic>
+#include <string>
 
 namespace DJI {
 namespace OSDK {


### PR DESCRIPTION
Slight changes in compilation order can cause the use of std::string in mmap_file_buffer.hpp to fail.