### PR TITLE
fix #868: occassional initialization segfault

### DIFF
--- a/osdk-core/api/src/dji_subscription.cpp
+++ b/osdk-core/api/src/dji_subscription.cpp
@@ -575,8 +575,7 @@ SubscriptionPackage::SubscriptionPackage()
   , incomingDataBuffer(NULL)
   , packageDataSize(0)
 {
-  userUnpackHandler.callback = NULL;
-  userUnpackHandler.userData = NULL;
+  cleanUpPackage();
 }
 
 SubscriptionPackage::~SubscriptionPackage()


### PR DESCRIPTION
This commit initializes PackageInfo in SubscriptionPackage to prevent segfaults when the class is initialized with a memory page that's dirty.