### PR TITLE
bump cmake minimum version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(onboardsdk)
 
 set(CMAKE_VERBOSE_MAKEFILE OFF)

--- a/osdk-core/CMakeLists.txt
+++ b/osdk-core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-core)
 
 

--- a/osdk-core/advanced-sensing/CMakeLists.txt
+++ b/osdk-core/advanced-sensing/CMakeLists.txt
@@ -4,7 +4,7 @@
 #*  please visit https://developer.dji.com/policies/eula/
 #*
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(advanced-sensing)
 
 unset(MY_CPU_ARCH)

--- a/sample/platform/linux/CMakeLists.txt
+++ b/sample/platform/linux/CMakeLists.txt
@@ -21,7 +21,7 @@
 # *
 
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(onboardsdk-linux-samples)
 
 # set(DJIOSDK_DIR ${OSDK_CORE_LIB_DIR}/lib/cmake/djiosdk)

--- a/sample/platform/linux/advanced-sensing/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-advanced-sensing-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -pthread -g -O0")

--- a/sample/platform/linux/advanced-sensing/camera_h264_callback_sample/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/camera_h264_callback_sample/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-liveview-sample)
 
 # Try to see if user has OpenCV installed

--- a/sample/platform/linux/advanced-sensing/camera_stream_callback_sample/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/camera_stream_callback_sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(camera-stream-callback-sample)
 
 # Try to see if user has OpenCV installed

--- a/sample/platform/linux/advanced-sensing/camera_stream_poll_sample/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/camera_stream_poll_sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(camera-stream-poll-sample)
 
 # Try to see if user has OpenCV installed

--- a/sample/platform/linux/advanced-sensing/camera_stream_target_tracking_sample/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/camera_stream_target_tracking_sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(camera-stream-target-tracking-sample)
 
 # Try to see if user has OpenCV installed

--- a/sample/platform/linux/advanced-sensing/stereo_vision_depth_perception_sample/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/stereo_vision_depth_perception_sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(stereo-vision-depth-perception-sample)
 
 find_path(OPENCV_CONTRIB_IMG_PROC

--- a/sample/platform/linux/advanced-sensing/stereo_vision_multi_thread_sample/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/stereo_vision_multi_thread_sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(stereo-vision-multi-thread-sample)
 
 # Try to see if user has OpenCV installed

--- a/sample/platform/linux/advanced-sensing/stereo_vision_new_sample/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/stereo_vision_new_sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(stereo-vision-new-sample)
 
 # Try to see if user has OpenCV installed

--- a/sample/platform/linux/advanced-sensing/stereo_vision_single_thread_sample/CMakeLists.txt
+++ b/sample/platform/linux/advanced-sensing/stereo_vision_single_thread_sample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(stereo-vision-single-thread-sample)
 
 # Try to see if user has OpenCV installed

--- a/sample/platform/linux/battery/CMakeLists.txt
+++ b/sample/platform/linux/battery/CMakeLists.txt
@@ -19,7 +19,7 @@
 # * SOFTWARE.
 # *
 # *
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-battery-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/config_tool/CMakeLists.txt
+++ b/sample/platform/linux/config_tool/CMakeLists.txt
@@ -19,7 +19,7 @@
 # * SOFTWARE.
 # *
 # *
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(config_tool)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0 -Wall -Werror")

--- a/sample/platform/linux/flight-control/CMakeLists.txt
+++ b/sample/platform/linux/flight-control/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-flightcontrol-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/hms/CMakeLists.txt
+++ b/sample/platform/linux/hms/CMakeLists.txt
@@ -19,7 +19,7 @@
 # * SOFTWARE.
 # *
 # *
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-hms-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/logging/CMakeLists.txt
+++ b/sample/platform/linux/logging/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-logging-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/mfio/CMakeLists.txt
+++ b/sample/platform/linux/mfio/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-mfio-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/missions/CMakeLists.txt
+++ b/sample/platform/linux/missions/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-mission-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/mobile/CMakeLists.txt
+++ b/sample/platform/linux/mobile/CMakeLists.txt
@@ -21,7 +21,7 @@
 # *
 
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-mobile-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/mop/CMakeLists.txt
+++ b/sample/platform/linux/mop/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(mop-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/payload-3rd-party/CMakeLists.txt
+++ b/sample/platform/linux/payload-3rd-party/CMakeLists.txt
@@ -19,7 +19,7 @@
 # * SOFTWARE.
 # *
 # *
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-payload-control-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/payloads/CMakeLists.txt
+++ b/sample/platform/linux/payloads/CMakeLists.txt
@@ -19,7 +19,7 @@
 # * SOFTWARE.
 # *
 # *
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-payloads-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0 -Wall -Werror")

--- a/sample/platform/linux/telemetry/CMakeLists.txt
+++ b/sample/platform/linux/telemetry/CMakeLists.txt
@@ -21,7 +21,7 @@
 # *
 
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(djiosdk-telemetry-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")

--- a/sample/platform/linux/time-sync/CMakeLists.txt
+++ b/sample/platform/linux/time-sync/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(time-sync-sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -O0")


### PR DESCRIPTION
Bump the minimum CMake version from 2.8 to 2.8.12 since anything below will soon be deprecated.