### PR TITLE
replace dangerous dereference of reinterpret_cast with memcpy

### DIFF
--- a/osdk-core/api/inc/dji_subscription.hpp
+++ b/osdk-core/api/inc/dji_subscription.hpp
@@ -343,7 +343,8 @@ public: // public methods
     lockMSG();
     if (p)
     {
-      ans = *reinterpret_cast<typename Telemetry::TypeMap<topic>::type*>(p);
+      size_t size = Telemetry::TopicDataBase[topic].size;
+      memcpy(&ans, p, size);
       freeMSG();
       return ans;
     }


### PR DESCRIPTION
On Raspberry Pi Zero 2W, compiling in Release mode introduced an issue where trying to call `vehicle->subscribe->getValue` crashed the program on `TOPIC_ALTITUDE_BAROMETER` and `TOPIC_ALTITUDE_FUSIONED`.

These issues appeared to be caused by the dereference of a `reinterpret_cast` call, specifically when the destination type was `float32_t`. A safer approach would be to use `memcpy` to simply grab the bytes from the buffer and copy them into a new stack variable. The Telemetry messages are so small that a single copy will not produce any significant performance penalty.

If, for some reason, `reinterpret_cast` is necessary, I'd love to know why that is and how I can get around the program crash when compiling with optimization.